### PR TITLE
Add '-std=c++14' to CCFLAGS to resolve build issues on macOS Big Sur.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -32,7 +32,8 @@ env['BUILDDIR'] = GetOption('build_dir')
 env.Append(
     ENV={'PATH': os.environ['PATH']},
     CPPPATH=[env.Dir('include')],
-    CCFLAGS=['-O3'],
+    CCFLAGS=['-O3', '-std=c++11'],
+    CXXFLAGS=['-std=c++11'],
 )
 
 env.Tool('gitversion')

--- a/SConstruct
+++ b/SConstruct
@@ -32,8 +32,8 @@ env['BUILDDIR'] = GetOption('build_dir')
 env.Append(
     ENV={'PATH': os.environ['PATH']},
     CPPPATH=[env.Dir('include')],
-    CCFLAGS=['-O3', '-std=c++11'],
-    CXXFLAGS=['-std=c++11'],
+    CCFLAGS=['-O3', '-std=c++14'],
+#    CXXFLAGS=['-std=c++11'],
 )
 
 env.Tool('gitversion')

--- a/SConstruct
+++ b/SConstruct
@@ -33,7 +33,6 @@ env.Append(
     ENV={'PATH': os.environ['PATH']},
     CPPPATH=[env.Dir('include')],
     CCFLAGS=['-O3', '-std=c++14'],
-#    CXXFLAGS=['-std=c++11'],
 )
 
 env.Tool('gitversion')


### PR DESCRIPTION
On macOS, at least on Big Sur but probably elsewhere as well, the default clang installation requires `-std=c++14` to be added to `CCFLAGS` (or  `CXXFLAGS`) for OpenDrop to build. I tried setting both `CCFLAGS` and `CXXFLAGS` as environment variables to overcome this issue, but neither of the environment variables were adhered to.