### PR TITLE
Remove incorrect note about commercial derivatives

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/__init__.py
+++ b/opendrop/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/__main__.py
+++ b/opendrop/__main__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/app.py
+++ b/opendrop/app/app.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/__init__.py
+++ b/opendrop/app/common/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/analysis_saver/__init__.py
+++ b/opendrop/app/common/analysis_saver/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/analysis_saver/figure_options/__init__.py
+++ b/opendrop/app/common/analysis_saver/figure_options/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/analysis_saver/figure_options/component.py
+++ b/opendrop/app/common/analysis_saver/figure_options/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/analysis_saver/figure_options/model.py
+++ b/opendrop/app/common/analysis_saver/figure_options/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/analysis_saver/misc.py
+++ b/opendrop/app/common/analysis_saver/misc.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/footer/__init__.py
+++ b/opendrop/app/common/footer/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/footer/analysis/__init__.py
+++ b/opendrop/app/common/footer/analysis/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/footer/analysis/_analysis.py
+++ b/opendrop/app/common/footer/analysis/_analysis.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/footer/analysis/_bar.py
+++ b/opendrop/app/common/footer/analysis/_bar.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/footer/linear.py
+++ b/opendrop/app/common/footer/linear.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/__init__.py
+++ b/opendrop/app/common/image_acquisition/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/configurator/__init__.py
+++ b/opendrop/app/common/image_acquisition/configurator/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/configurator/configurator.py
+++ b/opendrop/app/common/image_acquisition/configurator/configurator.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/configurator/local_storage/__init__.py
+++ b/opendrop/app/common/image_acquisition/configurator/local_storage/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/configurator/local_storage/component.py
+++ b/opendrop/app/common/image_acquisition/configurator/local_storage/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/configurator/usb_camera/__init__.py
+++ b/opendrop/app/common/image_acquisition/configurator/usb_camera/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_acquisition/image_acquisition.py
+++ b/opendrop/app/common/image_acquisition/image_acquisition.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/__init__.py
+++ b/opendrop/app/common/image_processing/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/image_processor/__init__.py
+++ b/opendrop/app/common/image_processing/image_processor/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/image_processor/component.py
+++ b/opendrop/app/common/image_processing/image_processor/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/image_processor/tool_panel/__init__.py
+++ b/opendrop/app/common/image_processing/image_processor/tool_panel/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/image_processor/tool_panel/component.py
+++ b/opendrop/app/common/image_processing/image_processor/tool_panel/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/image_processor/tool_panel/model.py
+++ b/opendrop/app/common/image_processing/image_processor/tool_panel/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/__init__.py
+++ b/opendrop/app/common/image_processing/plugins/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/define_line/__init__.py
+++ b/opendrop/app/common/image_processing/plugins/define_line/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/define_line/component.py
+++ b/opendrop/app/common/image_processing/plugins/define_line/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/define_line/model.py
+++ b/opendrop/app/common/image_processing/plugins/define_line/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/define_region/__init__.py
+++ b/opendrop/app/common/image_processing/plugins/define_region/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/define_region/component.py
+++ b/opendrop/app/common/image_processing/plugins/define_region/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/define_region/model.py
+++ b/opendrop/app/common/image_processing/plugins/define_region/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/preview/__init__.py
+++ b/opendrop/app/common/image_processing/plugins/preview/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/preview/image_sequence_navigator.py
+++ b/opendrop/app/common/image_processing/plugins/preview/image_sequence_navigator.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/image_processing/plugins/preview/model.py
+++ b/opendrop/app/common/image_processing/plugins/preview/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/__init__.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/base.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/base.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/camera.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/camera.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/genicam.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/genicam.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/image_sequence.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/image_sequence.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/local_storage.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/local_storage.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquirer/usb_camera.py
+++ b/opendrop/app/common/services/acquisition/_acquirer/usb_camera.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/common/services/acquisition/_acquisition.py
+++ b/opendrop/app/common/services/acquisition/_acquisition.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/__init__.py
+++ b/opendrop/app/conan/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/conan_experiment.py
+++ b/opendrop/app/conan/conan_experiment.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/__init__.py
+++ b/opendrop/app/conan/image_processing/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/image_processing.py
+++ b/opendrop/app/conan/image_processing/image_processing.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/image_processing.py
+++ b/opendrop/app/conan/image_processing/services/image_processing.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/__init__.py
+++ b/opendrop/app/conan/image_processing/services/plugins/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/baseline/__init__.py
+++ b/opendrop/app/conan/image_processing/services/plugins/baseline/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/baseline/component.py
+++ b/opendrop/app/conan/image_processing/services/plugins/baseline/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/preview/__init__.py
+++ b/opendrop/app/conan/image_processing/services/plugins/preview/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/preview/component.py
+++ b/opendrop/app/conan/image_processing/services/plugins/preview/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/preview/model.py
+++ b/opendrop/app/conan/image_processing/services/plugins/preview/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/roi/__init__.py
+++ b/opendrop/app/conan/image_processing/services/plugins/roi/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/roi/component.py
+++ b/opendrop/app/conan/image_processing/services/plugins/roi/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/thresh/__init__.py
+++ b/opendrop/app/conan/image_processing/services/plugins/thresh/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/thresh/component.py
+++ b/opendrop/app/conan/image_processing/services/plugins/thresh/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/thresh/model.py
+++ b/opendrop/app/conan/image_processing/services/plugins/thresh/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/image_processing/services/plugins/tool_id.py
+++ b/opendrop/app/conan/image_processing/services/plugins/tool_id.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/__init__.py
+++ b/opendrop/app/conan/report/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/graphs/__init__.py
+++ b/opendrop/app/conan/report/graphs/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/graphs/graphs.py
+++ b/opendrop/app/conan/report/graphs/graphs.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/graphs/services/graphs.py
+++ b/opendrop/app/conan/report/graphs/services/graphs.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/__init__.py
+++ b/opendrop/app/conan/report/overview/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/detail/__init__.py
+++ b/opendrop/app/conan/report/overview/detail/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/detail/detail.py
+++ b/opendrop/app/conan/report/overview/detail/detail.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/detail/image.py
+++ b/opendrop/app/conan/report/overview/detail/image.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/detail/residuals.py
+++ b/opendrop/app/conan/report/overview/detail/residuals.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/master.py
+++ b/opendrop/app/conan/report/overview/master.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/overview/overview.py
+++ b/opendrop/app/conan/report/overview/overview.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/report/report.py
+++ b/opendrop/app/conan/report/report.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/save_dialog/__init__.py
+++ b/opendrop/app/conan/save_dialog/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/save_dialog/component.py
+++ b/opendrop/app/conan/save_dialog/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/services/save.py
+++ b/opendrop/app/conan/services/save.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/conan/services/session.py
+++ b/opendrop/app/conan/services/session.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/__init__.py
+++ b/opendrop/app/ift/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/analysis_saver/__init__.py
+++ b/opendrop/app/ift/analysis_saver/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/analysis_saver/component.py
+++ b/opendrop/app/ift/analysis_saver/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/analysis_saver/model.py
+++ b/opendrop/app/ift/analysis_saver/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/analysis_saver/save_functions.py
+++ b/opendrop/app/ift/analysis_saver/save_functions.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/ift_experiment.py
+++ b/opendrop/app/ift/ift_experiment.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/image_processing.py
+++ b/opendrop/app/ift/image_processing/image_processing.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/image_processing.py
+++ b/opendrop/app/ift/image_processing/services/image_processing.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/__init__.py
+++ b/opendrop/app/ift/image_processing/services/plugins/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/drop_region/__init__.py
+++ b/opendrop/app/ift/image_processing/services/plugins/drop_region/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/drop_region/component.py
+++ b/opendrop/app/ift/image_processing/services/plugins/drop_region/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/edge_detection/__init__.py
+++ b/opendrop/app/ift/image_processing/services/plugins/edge_detection/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/edge_detection/component.py
+++ b/opendrop/app/ift/image_processing/services/plugins/edge_detection/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/edge_detection/model.py
+++ b/opendrop/app/ift/image_processing/services/plugins/edge_detection/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/needle_region/__init__.py
+++ b/opendrop/app/ift/image_processing/services/plugins/needle_region/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/needle_region/component.py
+++ b/opendrop/app/ift/image_processing/services/plugins/needle_region/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/preview/__init__.py
+++ b/opendrop/app/ift/image_processing/services/plugins/preview/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/preview/component.py
+++ b/opendrop/app/ift/image_processing/services/plugins/preview/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/preview/model.py
+++ b/opendrop/app/ift/image_processing/services/plugins/preview/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/image_processing/services/plugins/tool_id.py
+++ b/opendrop/app/ift/image_processing/services/plugins/tool_id.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/physical_parameters/__init__.py
+++ b/opendrop/app/ift/physical_parameters/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/physical_parameters/physical_parameters.py
+++ b/opendrop/app/ift/physical_parameters/physical_parameters.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/__init__.py
+++ b/opendrop/app/ift/report/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/graphs/graphs.py
+++ b/opendrop/app/ift/report/graphs/graphs.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/graphs/services/graphs.py
+++ b/opendrop/app/ift/report/graphs/services/graphs.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/__init__.py
+++ b/opendrop/app/ift/report/overview/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/detail/__init__.py
+++ b/opendrop/app/ift/report/overview/detail/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/detail/detail.py
+++ b/opendrop/app/ift/report/overview/detail/detail.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/detail/image.py
+++ b/opendrop/app/ift/report/overview/detail/image.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/detail/residuals.py
+++ b/opendrop/app/ift/report/overview/detail/residuals.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/master.py
+++ b/opendrop/app/ift/report/overview/master.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/overview/overview.py
+++ b/opendrop/app/ift/report/overview/overview.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/report/report.py
+++ b/opendrop/app/ift/report/report.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/services/analysis.py
+++ b/opendrop/app/ift/services/analysis.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/services/features.py
+++ b/opendrop/app/ift/services/features.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/services/quantities.py
+++ b/opendrop/app/ift/services/quantities.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/ift/services/session.py
+++ b/opendrop/app/ift/services/session.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/app/keyboard.py
+++ b/opendrop/app/keyboard.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/fit/younglaplace/model.py
+++ b/opendrop/fit/younglaplace/model.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/geometry.py
+++ b/opendrop/geometry.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/__init__.py
+++ b/opendrop/mvp/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/component.py
+++ b/opendrop/mvp/component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/entry_point.py
+++ b/opendrop/mvp/entry_point.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/gtk/__init__.py
+++ b/opendrop/mvp/gtk/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/gtk/stack.py
+++ b/opendrop/mvp/gtk/stack.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/presenter.py
+++ b/opendrop/mvp/presenter.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/typing.py
+++ b/opendrop/mvp/typing.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/mvp/view.py
+++ b/opendrop/mvp/view.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/utility/__init__.py
+++ b/opendrop/utility/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/utility/events/__init__.py
+++ b/opendrop/utility/events/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/utility/events/events.py
+++ b/opendrop/utility/events/events.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/utility/events/exceptions.py
+++ b/opendrop/utility/events/exceptions.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/utility/misc.py
+++ b/opendrop/utility/misc.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/__init__.py
+++ b/opendrop/widgets/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/canny_parameters.py
+++ b/opendrop/widgets/canny_parameters.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/error_dialog.py
+++ b/opendrop/widgets/error_dialog.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/file_chooser_button.py
+++ b/opendrop/widgets/file_chooser_button.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/float_entry.py
+++ b/opendrop/widgets/float_entry.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/integer_entry.py
+++ b/opendrop/widgets/integer_entry.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/validated_entry.py
+++ b/opendrop/widgets/validated_entry.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/opendrop/widgets/yes_no_dialog.py
+++ b/opendrop/widgets/yes_no_dialog.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/mvp/test_component.py
+++ b/tests/mvp/test_component.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/mvp/test_presenter.py
+++ b/tests/mvp/test_presenter.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/mvp/test_view.py
+++ b/tests/mvp/test_view.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/samples/__init__.py
+++ b/tests/samples/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/samples/dummy_pkg/__init__.py
+++ b/tests/samples/dummy_pkg/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/samples/dummy_pkg/module_a.py
+++ b/tests/samples/dummy_pkg/module_a.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/samples/dummy_pkg/subpkg/__init__.py
+++ b/tests/samples/dummy_pkg/subpkg/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/samples/dummy_pkg/subpkg/module_b.py
+++ b/tests/samples/dummy_pkg/subpkg/module_b.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/samples/other_dummy_pkg/__init__.py
+++ b/tests/samples/other_dummy_pkg/__init__.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/bindable/gextension/test_property.py
+++ b/tests/utility/bindable/gextension/test_property.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/bindable/gextension/test_style.py
+++ b/tests/utility/bindable/gextension/test_style.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/bindable/test_apply.py
+++ b/tests/utility/bindable/test_apply.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/bindable/test_bindable.py
+++ b/tests/utility/bindable/test_bindable.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/bindable/test_binding.py
+++ b/tests/utility/bindable/test_binding.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/events/test_events.py
+++ b/tests/utility/events/test_events.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:

--- a/tests/utility/test_misc.py
+++ b/tests/utility/test_misc.py
@@ -1,7 +1,6 @@
 # Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
 # OpenDrop is released under the GNU GPL License. You are free to
 # modify and distribute the code, but always under the same license
-# (i.e. you cannot make commercial derivatives).
 #
 # If you use this software in your research, please cite the following
 # journal articles:


### PR DESCRIPTION
opendrop currently contains the following comment in lots of places in the code:

```
# Copyright © 2020, Joseph Berry, Rico Tabor (opendrop.dev@gmail.com)
# OpenDrop is released under the GNU GPL License. You are free to
# modify and distribute the code, but always under the same license
# (i.e. you cannot make commercial derivatives).
```

The parenthetical comment on line 4 is at odds with the stated licence of GNU GPL. There is nothing within any version of the GNU GPL that precludes commercial use of the code; rather, any commercial user of the code must also provide the source code of their tools when it is distributed. In fact, the GPL promises that you *cannot* make this sort of restriction (see §10 of the LICENSE text which says that additional restrictions cannot be imposed). The current licensing of opendrop is thus self-contradictory meaning either the additional restriction is either immediately void, or that opendrop is not distributable at all. (Debian and Ubuntu typically take the latter position about conflicting licence statements.)

For a project like opendrop, the GNU GPL licence statement already means that if a company wants to modify or use opendrop they're allowed to, but they have to give all their users the source code of the modified version of opendrop *and* their code that calls opendrop. That's actually an even better outcome than trying to prevent them from using it.

Further information about commercial licensing and the GPL is contained in the GPL FAQ:
  * [can I prevent commercial uses](https://www.gnu.org/licenses/gpl-faq.en.html#NoMilitary)
  * [can I distribute GPL'd code commercially](https://www.gnu.org/licenses/gpl-faq.en.html#GPLCommercially)

This PR removes the offending line from each source code file.